### PR TITLE
feat: Add local decktape Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,8 @@ decktape: talk.md
 	docker run --rm -v ${dir_path}:/slides/ astefanutti/decktape \
 	https://matthewfeickert.github.io/${current_dir}/index.html?p=talk.md \
 	talk.pdf
+
+decktape_local: talk.md
+	docker run --rm -t --net=host -v ${dir_path}:/slides astefanutti/decktape:2.11.0 \
+	http://localhost:8001 \
+	localhost_draft.pdf


### PR DESCRIPTION
Run `decktape` in local mode to be able to produce PDF of slides from running on local host