### PR TITLE
fix: Pin decktape for stable export to PDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ default: decktape
 all: decktape
 
 decktape: talk.md
-	docker run --rm -v ${dir_path}:/slides/ astefanutti/decktape \
+	docker run --rm -v ${dir_path}:/slides/ astefanutti/decktape:3.0.0 \
 	https://matthewfeickert.github.io/${current_dir}/index.html?p=talk.md \
 	talk.pdf
 
 decktape_local: talk.md
-	docker run --rm -t --net=host -v ${dir_path}:/slides astefanutti/decktape:2.11.0 \
+	docker run --rm -t --net=host -v ${dir_path}:/slides astefanutti/decktape:3.0.0 \
 	http://localhost:8001 \
 	localhost_draft.pdf


### PR DESCRIPTION
Decktape `v2.11.0` was rendering the Standard Model coffee mug upside down

![bad_decktape](https://user-images.githubusercontent.com/5142394/87844731-dd772500-c885-11ea-8401-94d4d569382c.png)


Updating to use [v3.0.0](https://github.com/astefanutti/decktape/releases/tag/v3.0.0) properly exports the talk.